### PR TITLE
Added support for django 2 and python 3.6.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ pip-log.txt
 nosetests.xml
 htmlcov
 testing.db
+.pytest_cache*
 
 # Translations
 *.mo

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,25 +3,18 @@
 language: python
 
 python:
+  - "3.6"
   - "3.5"
-
-env:
-  - TOX_ENV=py35-django-110
-  - TOX_ENV=py34-django-110
-  - TOX_ENV=py27-django-110
-  - TOX_ENV=py35-django-111
-  - TOX_ENV=py34-django-111
-  - TOX_ENV=py27-django-111
-  - TOX_ENV=flake8
 
 matrix:
   fast_finish: true
 
-# command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
-install: pip install -r requirements_test.txt
+install:
+  - pip install -r requirements_test.txt
+  - pip install tox-travis
 
-# command to run tests using coverage, e.g. python setup.py test
-script: tox -e $TOX_ENV
+before_script: flake8
 
-after_success:
-  - codecov -e TOX_ENV
+script: tox
+
+after_success: codecov

--- a/setup.py
+++ b/setup.py
@@ -67,15 +67,13 @@ setup(
     classifiers=[
         'Development Status :: 4 - Beta',
         'Framework :: Django',
-        'Framework :: Django :: 1.10',
         'Framework :: Django :: 1.11',
+        'Framework :: Django :: 2.0',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    {py27,py34,py35}-django-110
-    {py27,py34,py35,py36}-django-111
+    {py35,py36}-django-111
+    {py35,py36}-django-2
     flake8
 
 [pytest]
@@ -23,11 +23,9 @@ setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/genomix
 commands = py.test --basetemp={envtmpdir} --cov={toxinidir}/genomix --cov-report=term-missing --verbose
 deps =
-    django-110: Django>=1.10,<1.11
     django-111: Django>=1.11,<2.0
+    django-2: Django>=2.0
     -r{toxinidir}/requirements_test.txt
 basepython =
     py36: python3.6
     py35: python3.5
-    py34: python3.4
-    py27: python2.7


### PR DESCRIPTION
Dear Maintainers,

Please accept this PR that addresses the following issues:
+ *Added support for django 2.0 and python 3.6*
+ *Dropped support for django 1.10 and python2.7 and python3.4*

Testing Done:
+ Unittests are included

